### PR TITLE
[APP-4422] re-use connection for all queries in executeEntitiesAndRawResults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.3.0-alpha.22",
+  "version": "0.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gather/typeorm",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, MongoDB databases.",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2074,6 +2074,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             const relationAlias = relation.inverseEntityMetadata.targetName;
 
             const queryBuilder = this.createQueryBuilder()
+                .setQueryRunner(queryRunner)
                 .select(relationAlias)
                 .from(relationTarget, relationAlias)
                 .setFindOptions({


### PR DESCRIPTION
## Issue
When running 10 or more `findOne` queries (that include a relation) concurrently, the request hangs indefinitely since the connection pool's max number of clients has been exceeded ([default 10](https://node-postgres.com/api/pool)).

When the `findOne` method is run it creates a `PoolClient` to query the parent record, then creates a separate `PoolClient` to query each relation column. Since the first `PoolClient` used to query the parent record is not immediately released (all pool clients are released only after all queries have been run) it causes the second query to wait indefinitely for an open connection.

This PR updates the `queryBuilder` used in this method to re-use the previous postgres connection instead of creating a separate connection.

## Steps to reproduce or a small repository showing the problem
https://github.com/tcampb/typeorm-postgres